### PR TITLE
platform.json avoid systemd-sonic-generator Failed to open report

### DIFF
--- a/rd98dx35xx_cn9131/scripts/rd98dx35xx-cn9131-init.sh
+++ b/rd98dx35xx_cn9131/scripts/rd98dx35xx-cn9131-init.sh
@@ -12,4 +12,7 @@ rd98dx35xx-cn9131_profile()
 # - Main entry
 rd98dx35xx-cn9131_profile
 
+# Dummy platform.json to eliminate "systemd-sonic-generator: Failed to open"
+echo "{ }" > /usr/share/sonic/device/arm64-marvell_rd98DX35xx_cn9131-r0/platform.json
+
 exit 0

--- a/rd98dx45xx_cn9131/scripts/rd98dx45xx-cn9131-init.sh
+++ b/rd98dx45xx_cn9131/scripts/rd98dx45xx-cn9131-init.sh
@@ -12,4 +12,7 @@ rd98dx45xx-cn9131_profile()
 # - Main entry
 rd98dx45xx-cn9131_profile
 
+# Dummy platform.json to eliminate "systemd-sonic-generator: Failed to open"
+echo "{ }" > /usr/share/sonic/device/arm64-marvell_rd98DX45xx_cn9131-r0/platform.json
+
 exit 0


### PR DESCRIPTION
Run-time create platform.json file containing only {} to avoid frequent error-prints
      "systemd-sonic-generator Failed to open platform.json"

This DUMMY is enough since real Port-configuration is generated from the file port_config.ini.

NOTE: this platform.json can't be in repo since it fails on system-health
   testing at build-time.