### PR TITLE
db98cx85xx init: rmmod-kempld

### DIFF
--- a/db98cx8514-10cc/scripts/db98cx8514-10cc-init.sh
+++ b/db98cx8514-10cc/scripts/db98cx8514-10cc-init.sh
@@ -16,4 +16,9 @@ echo optoe2 0x50 > /sys/bus/i2c/devices/i2c-2/new_device
 # Disable BIOS ACPI interrupt
 echo disable > /sys/firmware/acpi/interrupts/gpe01
 
+# Remove Kontron kempld modules (causing starvation on i2c bus)
+rmmod i2c_kempld || true
+rmmod gpio_kempld || true
+rmmod kempld_core || true
+
 exit 0

--- a/db98cx8522-10cc/scripts/db98cx8522-10cc-init.sh
+++ b/db98cx8522-10cc/scripts/db98cx8522-10cc-init.sh
@@ -18,4 +18,9 @@ echo optoe2 0x50 > /sys/bus/i2c/devices/i2c-2/new_device
 # Disable BIOS ACPI interrupt
 echo disable > /sys/firmware/acpi/interrupts/gpe01
 
+# Remove Kontron kempld modules (causing starvation on i2c bus)
+rmmod i2c_kempld || true
+rmmod gpio_kempld || true
+rmmod kempld_core || true
+
 exit 0

--- a/db98cx8540-16cd/scripts/db98cx8540-16cd-init.sh
+++ b/db98cx8540-16cd/scripts/db98cx8540-16cd-init.sh
@@ -18,4 +18,9 @@ echo optoe2 0x50 > /sys/bus/i2c/devices/i2c-2/new_device
 # Disable BIOS ACPI interrupt
 echo disable > /sys/firmware/acpi/interrupts/gpe01
 
+# Remove Kontron kempld modules (causing starvation on i2c bus)
+rmmod i2c_kempld || true
+rmmod gpio_kempld || true
+rmmod kempld_core || true
+
 exit 0


### PR DESCRIPTION
Remove Kontron kempld modules causing i2c-bus starvation on each FALCON-Intel board-model.

The starvation is seen (for example) long-latency several minutes commands' execution
         on "reboot" and on "show interfaces status".
The starvation depends upon HW "COMe-bBD7 E2" CPU-module on board.
For example, the same board-model 8514 (8535) but 2 devices:
  - Rev 2.0.0, FPD Rev P201.0009  -- starves
  - Rev 1.0.2, FPD Rev P102.0046  -- isn't

Before removing there are 3 busses i2c-0/1/2 with "empty" i2c-1 and with i2c-2:
     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
00:                         -- -- -- -- -- -- -- --
10: -- -- -- -- -- -- -- -- 18 -- -- -- -- -- -- --
20: -- -- 22 -- -- -- -- -- -- -- -- -- 2c -- -- --
30: 30 -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
40: 40 -- 42 43 -- -- -- -- -- -- -- -- 4c 4d 4e 4f
50: UU UU -- 53 -- -- -- -- 58 59 -- -- -- -- -- --
60: -- -- -- -- -- -- 66 -- 68 -- 6a 6b -- -- -- --
70: -- -- -- -- -- -- -- 77
After removing the i2c-2 is disappeared, i2c-1 has same devices as i2c-0.
